### PR TITLE
Use absolute path to run main.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ FROM gcr.io/distroless/python3-debian10
 COPY --from=builder /app /app
 WORKDIR /app
 ENV PYTHONPATH /app
-CMD ["main.py"]
+CMD ["/app/main.py"]


### PR DESCRIPTION
Fixes #1

For {unknown reasons}, a relative path wasn't allowing `main.py` to be found when the action was called from a different repository, so switch to an absolute path.

