### PR TITLE
fix: set action output by writing to environment file

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,19 @@
 import os
 import requests  # noqa We are just importing this to prove the dependency installed correctly
 
+# Set the output value by writing to the outputs in the Environment File, mimicking the behavior defined here:
+#  https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+def set_github_action_output(output_name, output_value):
+    f = open(os.path.abspath(os.environ["GITHUB_OUTPUT"]), "a")
+    f.write(f'{output_name}={output_value}')
+    f.close()    
 
 def main():
     my_input = os.environ["INPUT_MYINPUT"]
 
-    my_output = f"Hello {my_input}"
+    my_output = f'Hello {my_input}'
 
-    print(f"::set-output name=myOutput::{my_output}")
+    set_github_action_output('myOutput', my_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change method of setting Action output by writing to the environment file found by accessing the GITHUB_OUTPUT environment variable. 

This has been done due to the deprecation of the set-output command as noted [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)